### PR TITLE
Feat/북토크 삭제 모듈 추가

### DIFF
--- a/src/main/java/org/sophy/sophy/InitDb.java
+++ b/src/main/java/org/sophy/sophy/InitDb.java
@@ -899,6 +899,23 @@ public class InitDb {
                     .build();
             em.persist(booktalk27);
 
+            Booktalk booktalk28 = Booktalk.builder()
+                    .place(place1)
+                    .title("테스트용 북토크")
+                    .booktalkImageUrl("dwqE@EWQDQFQEWQ")
+                    .book(book5)
+                    .member(author2)
+                    .bookCategory(book11.getBookCategory())
+                    .startDate(LocalDateTime.of(2023, 8, 24, 11, 0))
+                    .endDate(LocalDateTime.of(2023, 8, 24, 12, 0))
+                    .maximum(4)
+                    .participationFee(0)
+                    .preliminaryInfo(PreliminaryInfo.COMFORTABLE_COMING)
+                    .description("항상 새로운 아이디어가 쏟아지는 시대, 아이디어를 찾는 방법도 여러 가지. 하루하루 아이디어를 위해 새로움을 찾는 마케터들은 어떤 방법을 쓸까요? 마케터 이승희의 영감을 만나보세요!")
+                    .booktalkStatus(BooktalkStatus.RECRUITING)
+                    .build();
+            em.persist(booktalk28);
+
             MemberBooktalk memberBooktalk = MemberBooktalk.builder()
                     .member(citizen)
                     .booktalk(booktalk1)
@@ -909,8 +926,14 @@ public class InitDb {
                     .booktalk(booktalk2)
                     .build();
 
+            MemberBooktalk memberBooktalk28 = MemberBooktalk.builder()
+                    .member(citizen)
+                    .booktalk(booktalk28)
+                    .build();
+
             em.persist(memberBooktalk);
             em.persist(memberBooktalk2);
+            em.persist(memberBooktalk28);
 
             CompletedBooktalk completedBooktalk = CompletedBooktalk.builder()
                     .title("끝난 북토크")

--- a/src/main/java/org/sophy/sophy/controller/BooktalkController.java
+++ b/src/main/java/org/sophy/sophy/controller/BooktalkController.java
@@ -2,6 +2,7 @@ package org.sophy.sophy.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.sophy.sophy.common.dto.ApiResponseDto;
+import org.sophy.sophy.domain.CompletedBooktalk;
 import org.sophy.sophy.domain.dto.booktalk.BooktalkUpdateDto;
 import org.sophy.sophy.domain.dto.booktalk.request.BooktalkParticipationRequestDto;
 import org.sophy.sophy.domain.dto.booktalk.request.BooktalkRequestDto;
@@ -61,5 +62,11 @@ public class BooktalkController {
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<List<BooktalkDeadlineUpcomingDto>> getBooktalkDeadlineUpcoming() {
         return ApiResponseDto.success(SuccessStatus.GET_BOOKTALKS_DEADLINE_UPCOMING_SUCCESS, booktalkService.getBooktalkDeadlineUpcoming());
+    }
+
+    @PostMapping("/{booktalkId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<CompletedBooktalk> completeBooktalk(@PathVariable("booktalkId") Long booktalkId) {
+        return ApiResponseDto.success(SuccessStatus.DELETE_BOOKTALK_SUCCESS, booktalkService.completeBooktalk(booktalkId));
     }
 }

--- a/src/main/java/org/sophy/sophy/domain/Booktalk.java
+++ b/src/main/java/org/sophy/sophy/domain/Booktalk.java
@@ -3,6 +3,8 @@ package org.sophy.sophy.domain;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.sophy.sophy.domain.dto.booktalk.BooktalkUpdateDto;
 import org.sophy.sophy.domain.enumerate.BookCategory;
 import org.sophy.sophy.domain.enumerate.BooktalkStatus;
@@ -17,6 +19,8 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor
+@SQLDelete(sql = "UPDATE booktalk SET deleted = true WHERE booktalk_id=?")
+@Where(clause = "deleted=false")
 public class Booktalk extends AuditingTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -41,6 +45,10 @@ public class Booktalk extends AuditingTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_property_id")
     private AuthorProperty authorProperty;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "operator_property_id")
+    private OperatorProperty operatorProperty;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id")
@@ -73,16 +81,14 @@ public class Booktalk extends AuditingTimeEntity {
     @Enumerated(EnumType.STRING)
     private BooktalkStatus booktalkStatus;
 
-    @OneToMany(mappedBy = "booktalk")
+    @OneToMany(mappedBy = "booktalk", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberBooktalk> participantList = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "scheduled_booktalk_id")
     private ScheduledBooktalk scheduledBooktalk;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "operator_property_id")
-    private OperatorProperty operatorProperty;
+    private Boolean deleted = Boolean.FALSE;
 
     public void setBooktalkStatus(BooktalkStatus booktalkStatus) {
         this.booktalkStatus = booktalkStatus;

--- a/src/main/java/org/sophy/sophy/domain/CompletedBooktalk.java
+++ b/src/main/java/org/sophy/sophy/domain/CompletedBooktalk.java
@@ -19,7 +19,8 @@ public class CompletedBooktalk extends AuditingTimeEntity{
     private String authorName;
     private LocalDateTime booktalkDate;
     private String placeName;
-    @ManyToOne
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
작가가 북토크 완료 버튼을 누를 시 or 시간이 지나 자동으로 북토크가 완료될 시 
기존 북토크를 삭제 처리하고 완료된 북토크 엔티티를 생성해 저장하는 메서드를 추가했습니다.
* 소프트 삭제 기능 구현
* 북토크 스케줄러에 삭제 및 저장 기능 구현
* 작가가 북토크 완료시키는 메서드 구현
* 완료된 북토크 엔티티 필드에 지연로딩 추가

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
