### PR TITLE
fix: refresh token 일치하지 않을 시 SophyJwtException으로 수정

### DIFF
--- a/src/main/java/org/sophy/sophy/exception/ErrorStatus.java
+++ b/src/main/java/org/sophy/sophy/exception/ErrorStatus.java
@@ -25,6 +25,7 @@ public enum ErrorStatus {
     INVALID_ACCESS_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
     REFRESH_TOKEN_TIME_EXPIRED_EXCEPTION(HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다."),
     LOGOUT_REFRESH_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "로그아웃 하여 리프레시 토큰이 존재하지 않는 상태입니다."),
+    INVALID_REFRESH_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "리프레시 토큰의 정보가 일치하지 않습니다."),
 
     /**
      * 403 FORBIDDEN

--- a/src/main/java/org/sophy/sophy/service/common/AuthService.java
+++ b/src/main/java/org/sophy/sophy/service/common/AuthService.java
@@ -1,5 +1,6 @@
 package org.sophy.sophy.service.common;
 
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sophy.sophy.controller.dto.request.DuplCheckDto;
@@ -12,9 +13,11 @@ import org.sophy.sophy.exception.ErrorStatus;
 import org.sophy.sophy.exception.model.ExistEmailException;
 import org.sophy.sophy.exception.model.LogoutRefreshtokenException;
 import org.sophy.sophy.exception.model.SophyException;
+import org.sophy.sophy.exception.model.SophyJwtException;
 import org.sophy.sophy.infrastructure.MemberRepository;
 import org.sophy.sophy.jwt.TokenProvider;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -22,8 +25,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
-
-import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -136,7 +137,8 @@ public class AuthService {
 
         // 4. Refresh Token 일치하는지 검사
         if (!existRefreshToken.equals(refreshToken)) {
-            throw new RuntimeException("Refresh Token의 정보가 일치하지 않습니다.");
+            throw new SophyJwtException(HttpStatus.UNAUTHORIZED,
+                ErrorStatus.INVALID_REFRESH_TOKEN_EXCEPTION.getMessage());
         }
 
         // 5. 새로운 토큰 생성


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
  closed #104

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
reissue API에서 refresh token 일치하지 않을 시 RuntimeError 대신 SophyJwtException를 사용하여 예외처리하도록 수정
